### PR TITLE
Added alpha/beta parameters to LuceneRunQuery

### DIFF
--- a/src/main/java/edu/gslis/indexes/IndexWrapperLuceneImpl.java
+++ b/src/main/java/edu/gslis/indexes/IndexWrapperLuceneImpl.java
@@ -978,7 +978,7 @@ public class IndexWrapperLuceneImpl implements IndexWrapper {
 			if (params.get("k1") != null)
 				k1 = Float.parseFloat(params.get("k1"));
 			if (params.get("b") != null)
-				k1 = Float.parseFloat(params.get("b"));
+				b = Float.parseFloat(params.get("b"));
 			similarity = new BM25Similarity(k1, b);
 		} else if (method.equals("tfidf")) {
 			similarity = new ClassicSimilarity();

--- a/src/main/java/edu/gslis/lucene/main/LuceneRunQuery.java
+++ b/src/main/java/edu/gslis/lucene/main/LuceneRunQuery.java
@@ -82,7 +82,8 @@ public class LuceneRunQuery
             String stopwords = cmd.getOptionValue("stopwords");
             int fbDocs = Integer.parseInt(cmd.getOptionValue("fbDocs", "0"));
             int fbTerms = Integer.parseInt(cmd.getOptionValue("fbTerms", "0"));
-            double fbOrigWeight  = Double.parseDouble(cmd.getOptionValue("fbOrigWeight", "0"));
+            double fbAlpha  = Double.parseDouble(cmd.getOptionValue("alpha", "1"));
+            double fbBeta  = Double.parseDouble(cmd.getOptionValue("beta", "1"));
             
             GQueries gqueries = new GQueriesJsonImpl();
             if (!StringUtils.isEmpty(query)) {
@@ -106,7 +107,8 @@ public class LuceneRunQuery
             config.setRunName(runname);
             config.setFbDocs(fbDocs);
             config.setFbTerms(fbTerms);
-            config.setFbOrigWeight(fbOrigWeight);
+            config.setFbAlpha(fbAlpha);
+            config.setFbBeta(fbBeta);
             config.setNumResults(numResults);
         }            
         LuceneRunQuery runner = new LuceneRunQuery(config);
@@ -188,7 +190,8 @@ public class LuceneRunQuery
         IndexWrapper index = IndexWrapperFactory.getIndexWrapper(indexPath);
 
         if (config.getFbDocs() > 0 && config.getFbTerms() > 0) {
-        	System.err.println("Running Rocchio expansion: " + config.getFbDocs() + "," + config.getFbTerms() + "," + config.getFbOrigWeight());
+        	System.err.println("Running Rocchio expansion: " + config.getFbDocs() + "," + config.getFbTerms() +
+        			"," + config.getFbAlpha() + "," + config.getFbBeta());
         }
         
         // Run each query
@@ -205,7 +208,7 @@ public class LuceneRunQuery
         		double b = Double.parseDouble(params.get("b"));
         		double k1 = Double.parseDouble(params.get("k1"));
             	
-            	Rocchio rocchioFb = new Rocchio(config.getFbOrigWeight(), (1-config.getFbOrigWeight()), k1, b);
+            	Rocchio rocchioFb = new Rocchio(config.getFbAlpha(), config.getFbBeta(), k1, b);
             	rocchioFb.setStopper(stopper);
             	rocchioFb.expandQuery(index, query, config.getFbDocs(), config.getFbTerms());      	
             	            	
@@ -257,7 +260,8 @@ public class LuceneRunQuery
         options.addOption("name", true, "Run name");
         options.addOption("fbDocs", true, "Number of feedback documents");
         options.addOption("fbTerms", true, "Number of feedback terms");
-        options.addOption("fbOrigWeight", true, "Weight of original query");
+        options.addOption("alpha", true, "Rocchio alpha");
+        options.addOption("beta", true, "Rocchio beta");
         options.addOption("numResults", true, "Number of results (defaults to 10000");
 
         return options;

--- a/src/main/java/edu/gslis/lucene/main/config/RunQueryConfig.java
+++ b/src/main/java/edu/gslis/lucene/main/config/RunQueryConfig.java
@@ -15,7 +15,8 @@ public class RunQueryConfig {
     String runname = "";
     int fbDocs = 0;
     int fbTerms = 0;
-    double fbOrigWeight = 0;
+    double fbAlpha = 0;
+    double fbBeta = 0;
     int numResults = 0;
 
     
@@ -38,12 +39,18 @@ public class RunQueryConfig {
 	public void setFbTerms(int fbTerms) {
 		this.fbTerms = fbTerms;
 	}
-	public double getFbOrigWeight() {
-		return fbOrigWeight;
+	public double getFbAlpha() {
+		return fbAlpha;
 	}
-	public void setFbOrigWeight(double fbOrigWeight) {
-		this.fbOrigWeight = fbOrigWeight;
+	public void setFbAlpha(double fbAlpha) {
+		this.fbAlpha = fbAlpha;
 	}
+	public double getFbBeta() {
+		return fbBeta;
+	}
+	public void setFbBeta(double fbBeta) {
+		this.fbBeta = fbBeta;
+	}	
 	public String getIndex() {
         return index;
     }


### PR DESCRIPTION
See also https://opensource.ncsa.illinois.edu/jira/browse/NDS-959

* Changed LuceneRunQuery to use explicit alpha/beta for Rocchio instead of fbOrigWeight