### PR TITLE
Improvements to Featurevector

### DIFF
--- a/src/main/java/edu/gslis/textrepresentation/FeatureVector.java
+++ b/src/main/java/edu/gslis/textrepresentation/FeatureVector.java
@@ -78,6 +78,11 @@ public class FeatureVector  {
 	}
 
 	public void applyStopper(Stopper stopper) {
+		if (stopper == null) {
+			System.err.println("Warning: Applying a null stopper. Feature vector is unchanged.");
+			return;
+		}
+
 		for (String term : getFeatures()) {
 			if (stopper.isStopWord(term)) {
 				removeTerm(term);

--- a/src/main/java/edu/gslis/textrepresentation/FeatureVector.java
+++ b/src/main/java/edu/gslis/textrepresentation/FeatureVector.java
@@ -377,7 +377,7 @@ public class FeatureVector  {
 	 */
 	public static class Interpolate {
 		
-		private FeatureVector original = new FeatureVector(null);
+		private FeatureVector original;
 		private FeatureVector other = new FeatureVector(null);
 		private double origWeight = 0.5;
 		


### PR DESCRIPTION
From #18 
- Added applyStopper method to remove stop words in the feature vector
- Fixed bug where setTerm could lead to incorrect vector length
- Changed results of non-probability mixing weights to limit surprise
- Added Interpolate inner class to make interpolating clearer
- Removed unnecessary main method
- Did not remove setTerm or clarity methods to keep backwards compatibility.